### PR TITLE
Fixed issue with account IDs that start with 0 and fixed a typo.

### DIFF
--- a/disablesecurityhub.py
+++ b/disablesecurityhub.py
@@ -94,7 +94,7 @@ if __name__ == '__main__':
     
     # Setup command line arguments
     parser = argparse.ArgumentParser(description='Disable and unlink AWS Accounts from central SecurityHub Account')
-    parser.add_argument('--master_account', type=int, required=True, help="AccountId for Central AWS Account")
+    parser.add_argument('--master_account', type=str, required=True, help="AccountId for Central AWS Account")
     parser.add_argument('input_file', type=argparse.FileType('r'), help='Path to CSV file containing the list of account IDs and Email addresses')
     parser.add_argument('--assume_role', type=str, required=True, help="Role Name to assume in each account")
     parser.add_argument('--delete_master', action='store_true', default=False, help="Disable SecurityHub in Master")
@@ -103,7 +103,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
     
     # Validate master accountId
-    if not re.match(r'[0-9]{12}',str(args.master_account)):
+    if not re.match(r'[0-9]{12}',args.master_account):
         raise ValueError("Master AccountId is not valid")
     
     
@@ -168,7 +168,7 @@ if __name__ == '__main__':
                         try:
                             subscription_arn = 'arn:aws:securityhub:{}:{}:subscription/{}'.format(aws_region, account,standard.split(':')[-1].split('/',1)[1])
                             sh_client.batch_disable_standards(StandardsSubscriptionArns=[subscription_arn])
-                            print("Finished disabling stanard {} on account {} for region {}".format(standard,account, aws_region))
+                            print("Finished disabling standard {} on account {} for region {}".format(standard,account, aws_region))
                         except ClientError as e:
                             print("Error disabling standards for account {}".format(account))
                             failed_accounts.append({ account : repr(e)})


### PR DESCRIPTION
*Description of changes:*
Fixed issue with account IDs that start with 0. They must be treated as strings as is done in enablesecurityhub.py. Also fixed a typo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.