### PR TITLE
Enabled standards for Master Account fixed timeout for standards validation

### DIFF
--- a/enablesecurityhub.py
+++ b/enablesecurityhub.py
@@ -258,7 +258,33 @@ if __name__ == '__main__':
     for aws_region in securityhub_regions:
         master_clients[aws_region] = master_session.client('securityhub', region_name=aws_region)
         try: 
+            # Enable Security Hub for the Master Account 
             master_clients[aws_region].enable_security_hub()
+
+            # Enable compliance Standards for Master account 
+            compliance_standards_arns = [utils.get_standard_arn_for_region_and_resource(aws_region, standard) for standard in standards_arns]
+            batch_enable_standards_input = [{'StandardsArn': standard_arn} for standard_arn in compliance_standards_arns]
+            master_clients[aws_region].batch_enable_standards(StandardsSubscriptionRequests=batch_enable_standards_input)
+
+            # Verify standards get enabled in the Master Account 
+            standards_to_verify = compliance_standards_arns[:]
+            standards_status = {}
+            start_time = int(time.time())
+            while len(standards_to_verify) > 0:
+                if (int(time.time()) - start_time) > 100:
+                    print("Timeout waiting for READY state enabling standards {standards} in region {region} for account {account}, last state: {status}"
+                          .format(standards=compliance_standards_arns, region=aws_region, account=args.master_account, status=standards_status))
+                    break
+                enabled_standards = master_clients[aws_region].get_enabled_standards()
+                for enabled_standard in enabled_standards['StandardsSubscriptions']:
+                    enabled_standard_arn = enabled_standard['StandardsArn']
+                    enabled_standard_status = enabled_standard['StandardsStatus']
+                    standards_status[enabled_standard_arn] = enabled_standard_status
+                    if enabled_standard_arn in standards_to_verify and enabled_standard_status == 'READY':
+                        print("Finished enabling stanard {} on account {} for region {}".format(enabled_standard_arn, args.master_account, aws_region))
+                        standards_to_verify.remove(enabled_standard_arn)
+
+
         except ClientError as e:
             if e.response['Error']['Code'] == 'ResourceConflictException':
                 pass
@@ -313,7 +339,7 @@ if __name__ == '__main__':
                             enabled_standard_arn = enabled_standard['StandardsArn']
                             enabled_standard_status = enabled_standard['StandardsStatus']
                             standards_status[enabled_standard_arn] = enabled_standard_status
-                            if enabled_standard_arn in standards_to_verify and enabled_standard_status is 'READY':
+                            if enabled_standard_arn in standards_to_verify and enabled_standard_status == 'READY':
                                 print("Finished enabling stanard {} on account {} for region {}".format(enabled_standard_arn,account, aws_region))
                                 standards_to_verify.remove(enabled_standard_arn)
 


### PR DESCRIPTION
*Issue #, if available:*

Please let me know if you have any questions. Change details:
-  Added logic to enable standards for the Master Account (264-267)
-  Added logic to verify standards are enabled in the Master Account (269-285)
-  Updated logic for verifying standards are enabled in member accounts to resolve timeout issue (342)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
