### PR TITLE
Enables AWS Config check for the master account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+__pycache__


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This PR enables AWS Config check for the master account. Previously Config check was being done only for linked accounts.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
