### PR TITLE
Fix typo in standards message

### DIFF
--- a/enablesecurityhub.py
+++ b/enablesecurityhub.py
@@ -281,7 +281,7 @@ if __name__ == '__main__':
                     enabled_standard_status = enabled_standard['StandardsStatus']
                     standards_status[enabled_standard_arn] = enabled_standard_status
                     if enabled_standard_arn in standards_to_verify and enabled_standard_status == 'READY':
-                        print("Finished enabling stanard {} on account {} for region {}".format(enabled_standard_arn, args.master_account, aws_region))
+                        print("Finished enabling standard {} on account {} for region {}".format(enabled_standard_arn, args.master_account, aws_region))
                         standards_to_verify.remove(enabled_standard_arn)
 
 
@@ -343,7 +343,7 @@ if __name__ == '__main__':
                             enabled_standard_status = enabled_standard['StandardsStatus']
                             standards_status[enabled_standard_arn] = enabled_standard_status
                             if enabled_standard_arn in standards_to_verify and enabled_standard_status == 'READY':
-                                print("Finished enabling stanard {} on account {} for region {}".format(enabled_standard_arn,account, aws_region))
+                                print("Finished enabling standard {} on account {} for region {}".format(enabled_standard_arn,account, aws_region))
                                 standards_to_verify.remove(enabled_standard_arn)
 
 


### PR DESCRIPTION
This fixes a typo in the message displayed when enabling standards:

Before:
> Finished enabling stanard arn:…

After:
> Finished enabling standard arn:…


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
