### PR TITLE
Bug: Misconfiguration of arn at `utils.get_standard_arn_for_region_and_resource`

### DIFF
--- a/test_utils.py
+++ b/test_utils.py
@@ -1,0 +1,6 @@
+import utils
+
+region = 'ap-northeast-1'
+standard_resource = 'arn:aws:securityhub:::ruleset/pci-dss/v/3.2.1'
+
+print(utils.get_standard_arn_for_region_and_resource(region, standard_resource))

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,6 @@
 CIS_STANDARD_RESOURCE = 'ruleset/cis-aws-foundations-benchmark/v/1.2.0'
 CIS_STANDARD_ARN = 'arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0'
-"arn:aws:securityhub:us-west-2::standards/pci-dss/v/3.2.1"
+#"arn:aws:securityhub:us-west-2::standards/pci-dss/v/3.2.1"
 def get_standard_arn_for_region_and_resource(region, standard_resource):
     if standard_resource == CIS_STANDARD_ARN or standard_resource == CIS_STANDARD_RESOURCE:
         return CIS_STANDARD_ARN
@@ -8,5 +8,5 @@ def get_standard_arn_for_region_and_resource(region, standard_resource):
         return 'arn:{partition}:securityhub:{region}::{resource}'.format(
             partition='aws',
             region=region,
-            resource=standard_resource.spit(':').pop()
+            resource=standard_resource.split(':').pop()
         )

--- a/utils.py
+++ b/utils.py
@@ -5,4 +5,8 @@ def get_standard_arn_for_region_and_resource(region, standard_resource):
     if standard_resource == CIS_STANDARD_ARN or standard_resource == CIS_STANDARD_RESOURCE:
         return CIS_STANDARD_ARN
     else:
-        return 'arn:{partition}:securityhub:{region}::{resource}'.format(partition='aws', region=region, resource=standard_resource)
+        return 'arn:{partition}:securityhub:{region}::{resource}'.format(
+            partition='aws',
+            region=region,
+            resource=standard_resource.spit(':').pop()
+        )


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Following error occurs when trying to enable 'pci-dss'

```
Enabling the following Security Hub Standards for enabled account(s) and region(s): ['arn:aws:securityhub:::stardards/pci-dss/v/3.2.1']
Assumed session for 111111111111.
Won't try to link master account 111111111111 to itself
Assumed session for 111111111111.
Beginning 111111111111 in ap-northeast-1
Error Processing Account 111111111111
---------------------------------------------------------------
Failed Accounts
---------------------------------------------------------------
111111111111:
        InvalidInputException('An error occurred (InvalidInputException) when calling the BatchEnableStandards operation: Invalid StandardsSubscriptionRequest(s): [{"StandardsArn":"arn:aws:securityhub:ap-northeast-1::arn:aws:securityhub:::stardards/pci-dss/v/3.2.1"}]',)
---------------------------------------------------------------
```

I guess that's because given arn/ENABLE_STANDARDS is [not parsed properly](https://github.com/awslabs/aws-securityhub-multiaccount-scripts/blob/master/utils.py#L8).
When [calling the function](https://github.com/awslabs/aws-securityhub-multiaccount-scripts/blob/master/enablesecurityhub.py#L265) it passes arn.

Therefore I fixed `else` context of the function in order to ensure proper arn format for non-CIS stardards.
Confirmed working properly with ENABLE_STANDARDSs shown below

|ENABLE_STANDARDS|worked?|
|---|---|
|--enable_standards arn:aws:securityhub:::standards/pci-dss/v/3.2.1|yes|
|--enable_standards arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0,arn:aws:securityhub:::standards/pci-dss/v/3.2.1|yes|

Thanks


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
