### PR TITLE
fixed typo on format()

### DIFF
--- a/enablesecurityhub.py
+++ b/enablesecurityhub.py
@@ -289,7 +289,7 @@ if __name__ == '__main__':
             if e.response['Error']['Code'] == 'ResourceConflictException':
                 pass
             else:
-                print("Error: Unable to enable Security Hub on Master account in region {}").format(aws_region)
+                print("Error: Unable to enable Security Hub on Master account in region {}".format(aws_region))
                 raise SystemExit(0)
 
         members[aws_region] = get_master_members(master_clients[aws_region], aws_region)


### PR DESCRIPTION
When run as is, if the attempt to enable security hub fails, the exception handler throws an error because of a typo. Instead of `print("string".format(aws_region))` the line of code is `print("string").format(aws_region)`. Syntactically valid, but wrong. When that line is executed, you see:

```
Error: Unable to enable Security Hub on Master account in region {}
Traceback (most recent call last):
  File "enablesecurityhub.py", line 263, in <module>
    master_clients[aws_region].enable_security_hub()
  File "/Users/pacohope/lib/python3/lib/python3.7/site-packages/botocore/client.py", line 316, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Users/pacohope/lib/python3/lib/python3.7/site-packages/botocore/client.py", line 635, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (UnrecognizedClientException) when calling the EnableSecurityHub operation: The security token included in the request is invalid

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "enablesecurityhub.py", line 293, in <module>
    print("Error: Unable to enable Security Hub on Master account in region {}").format(aws_region)
AttributeError: 'NoneType' object has no attribute 'format'
```

*Description of changes:*

A super-simple, one-character change. Moving the close parenthesis.

> By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
