### PR TITLE
feat: Add Security Hub multi-account product disablement script

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 This repository contains scripts and guidance for enabling and configuring Security Hub and Security Hub features across multiple accounts.  
 
-The three scenarios addressed by this repository are:
+The five scenarios addressed by this repository are:
 * [Multi-account enablement scripts](multiaccount-enable) - scripts focused on enabling or disabling Security Hub across many accounts.  Applicable for accounts that are not managed by a [delegated administrator](https://docs.aws.amazon.com/securityhub/latest/userguide/designate-orgs-admin-account.html) account. 
 
 * [Multi-account CIS 1.4 enable scripts](cis14-enable) - scripts focused on enabling the Center for Internet Security AWS Foundational Best Practices v1.4 security standard across many accounts.  
@@ -20,5 +20,4 @@ The three scenarios addressed by this repository are:
  
 * [Multi-region automation rules deployment](automation-rules) - scripts focused on deploying automation rules across multiple regions in an account.
 
-
-
+* [Multi-account product disablement scripts](multiaccount-product-disablement) - scripts focused on disabling Security Hub product integrations across multiple accounts, with support for dry-run mode to preview changes before execution.

--- a/multiaccount-product-disablement/README.md
+++ b/multiaccount-product-disablement/README.md
@@ -1,0 +1,489 @@
+# AWS Security Hub Multi-Account Product Disablement Script
+
+## Overview
+
+This script automates the process of disabling specific AWS Security Hub CSPM product integrations across multiple AWS accounts in an AWS Organization. It must be run from the Security Hub CSPM Delegated Administrator account.
+
+## License Summary
+
+This sample code is made available under a modified MIT license. See the LICENSE file.
+
+## Account Roles
+
+This script works in an AWS Organizations setup with Security Hub CSPM enabled, using a Delegated Administrator account model:
+
+**Security Hub CSPM Delegated Administrator Account:**
+- This is where you RUN the script
+- The account designated as the Delegated Administrator for Security Hub CSPM in your AWS Organization
+- Has organizational visibility into all Security Hub CSPM member accounts
+- Can list members and assume roles in member accounts
+- Example: Your central security/compliance account
+
+**Member Accounts:**
+- These are the accounts where products will be DISABLED
+- Organization member accounts that are enabled for Security Hub CSPM
+- Must have an IAM role that trusts the Delegated Administrator account
+- Example: Your application accounts, workload accounts, sandbox accounts
+
+## Prerequisites
+
+### Delegated Administrator (DA) Account
+
+The DA account (where you run the script) must have these permissions:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "securityhub:ListMembers",
+                "sts:AssumeRole"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
+
+This allows the DA account to:
+- List all Security Hub member accounts
+- Assume roles in member accounts to disable products
+
+### Member Accounts (Target Accounts)
+
+Each member account must have an IAM role with:
+
+1. **IAM permissions** to disable products:
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "securityhub:DisableImportFindingsForProduct"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
+
+2. **Trust policy** that grants the DA account permission to assume this role:
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [{
+        "Effect": "Allow",
+        "Principal": {
+            "AWS": "arn:aws:iam::DA_ACCOUNT_ID:root"
+        },
+        "Action": "sts:AssumeRole"
+    }]
+}
+```
+
+**Important:** 
+- The role name must be the same in ALL member accounts (e.g., `SecurityHubRole`)
+- Replace `DA_ACCOUNT_ID` with your actual DA account ID
+- The trust policy is what grants the DA account STS access to assume the role
+
+### Quick Setup Summary
+
+1. **In DA Account (where you run the script):**
+   - Attach permissions: `securityhub:ListMembers`, `sts:AssumeRole`
+
+2. **In Each Member Account (where products will be disabled):**
+   - Create IAM role named `SecurityHubRole`
+   - Attach permission: `securityhub:DisableImportFindingsForProduct`
+   - Set trust policy to allow DA account to assume the role (grants STS access)
+
+3. **Ensure accounts are Security Hub members:**
+   - From DA account: `aws securityhub create-members --region REGION --account-details ...`
+
+### Optional: CSV File
+
+A CSV file with account IDs to process. Accounts should be listed one per line with the account ID. Format: `AccountId`. See `accounts.csv.example` for a sample file.
+- If CSV is provided: Script processes **accounts from the CSV file**
+- If CSV is not provided: Script processes **all Security Hub member accounts**
+
+### Software Requirements
+
+Python 2.7+ or Python 3.x with boto3 library installed
+
+## Important: STS Regional Endpoint Configuration
+
+⚠️ **CRITICAL:** This script requires regional STS endpoints to be enabled.
+
+### Quick Setup (Run Before Script)
+
+```bash
+export AWS_STS_REGIONAL_ENDPOINTS=regional
+export AWS_DEFAULT_REGION=<preferred_region>
+```
+
+### Permanent Setup (Recommended)
+
+Add to your `~/.aws/config` file:
+
+```ini
+[default]
+sts_regional_endpoints = regional
+region = us-east-1  # or your preferred region
+```
+
+Or use the following command to append it automatically:
+
+```bash
+cat >> ~/.aws/config << 'EOF'
+
+[default]
+sts_regional_endpoints = regional
+EOF
+```
+
+### Why This Is Required
+
+AWS is enforcing regional STS endpoints for security and compliance. Without this setting, you'll encounter errors like:
+
+```
+AccessDenied when calling GetCallerIdentity operation: 
+You are currently using the legacy global endpoint. 
+Please switch to the regional endpoint instead.
+```
+
+**What it does:** This setting tells the AWS SDK to use regional STS endpoints (e.g., `sts.us-east-1.amazonaws.com`) instead of the legacy global endpoint (`sts.amazonaws.com`).
+
+**Impact:** This setting applies to ALL STS operations and works across ALL regions the script processes.
+
+For more information: [AWS STS Regionalized Endpoints Documentation](https://docs.aws.amazon.com/sdkref/latest/guide/feature-sts-regionalized-endpoints.html)
+
+## Creating the IAM Role
+
+If the SecurityHubRole doesn't exist in your member accounts, create it using the AWS CLI:
+
+```bash
+# Run these commands in EACH MEMBER ACCOUNT (not the DA account)
+
+# 1. Create trust policy
+# Replace 123456789012 with your DA account ID (where you run the script)
+cat > trust-policy.json << 'EOF'
+{
+    "Version": "2012-10-17",
+    "Statement": [{
+        "Effect": "Allow",
+        "Principal": {
+            "AWS": "arn:aws:iam::123456789012:root"
+        },
+        "Action": "sts:AssumeRole"
+    }]
+}
+EOF
+
+# 2. Create IAM policy
+cat > iam-policy.json << 'EOF'
+{
+    "Version": "2012-10-17",
+    "Statement": [{
+        "Effect": "Allow",
+        "Action": [
+            "securityhub:DisableImportFindingsForProduct"
+        ],
+        "Resource": "*"
+    }]
+}
+EOF
+
+# 3. Create role
+aws iam create-role \
+    --role-name SecurityHubRole \
+    --assume-role-policy-document file://trust-policy.json
+
+# 4. Attach policy
+aws iam put-role-policy \
+    --role-name SecurityHubRole \
+    --policy-name SecurityHubProductManagement \
+    --policy-document file://iam-policy.json
+```
+
+**Note:** The trust policy (step 1) grants the DA account STS access to assume this role. This is required for cross-account access.
+
+## Automated Role Deployment Using CloudFormation StackSets (Recommended for Large Organizations)
+
+### Overview
+
+For organizations with hundreds or thousands of member accounts, manually creating IAM roles in each account is impractical. **CloudFormation StackSets** provides an automated solution to deploy the required IAM role across all member accounts simultaneously from your AWS Organizations management account.
+
+### Prerequisites
+
+1. **Access to Management Account** - You need administrative access to your AWS Organizations management account
+2. **Organizations Integration** - CloudFormation StackSets must have trusted access enabled with AWS Organizations
+3. **DA Account ID** - Know your Security Hub CSPM Delegated Administrator account ID
+
+### Step 1: Enable StackSets with Organizations (One-Time Setup)
+
+This step only needs to be done once for your organization.
+
+#### Option A: AWS Console (Recommended)
+
+1. Log into your **Management Account**
+2. Navigate to: **CloudFormation → StackSets** (https://console.aws.amazon.com/cloudformation/home#/stacksets)
+3. If prompted, click **"Enable trusted access with AWS Organizations"**
+4. Confirmation: You should see StackSets enabled
+
+#### Option B: AWS CLI
+
+```bash
+# Enable trusted access
+aws organizations enable-aws-service-access \
+    --service-principal member.org.stacksets.cloudformation.amazonaws.com
+
+# Verify it's enabled
+aws organizations list-aws-service-access-for-organization \
+    --query 'EnabledServicePrincipals[?ServicePrincipal==`member.org.stacksets.cloudformation.amazonaws.com`]'
+```
+
+### Step 2: Use the CloudFormation Template
+
+The CloudFormation template is provided in this directory as `SecurityHubRole-StackSet.yaml`. This template:
+- Creates an IAM role named `SecurityHubRole` in each member account
+- Configures the trust policy to allow your DA account to assume the role
+- Attaches the necessary Security Hub permissions
+- Tags resources for tracking
+
+**Template file:** `SecurityHubRole-StackSet.yaml` (included in this directory)
+
+### Step 3: Deploy the StackSet
+
+Replace `YOUR_DA_ACCOUNT_ID` with your actual Delegated Administrator account ID:
+
+```bash
+# Create the StackSet
+aws cloudformation create-stack-set \
+    --region us-east-1 \
+    --stack-set-name SecurityHubRoleDeployment \
+    --template-body file://SecurityHubRole-StackSet.yaml \
+    --description "Deploy SecurityHub role to all member accounts" \
+    --parameters ParameterKey=DelegatedAdminAccountId,ParameterValue=YOUR_DA_ACCOUNT_ID \
+    --permission-model SERVICE_MANAGED \
+    --auto-deployment Enabled=true,RetainStacksOnAccountRemoval=false \
+    --capabilities CAPABILITY_NAMED_IAM
+```
+
+Expected output:
+```json
+{
+    "StackSetId": "SecurityHubRoleDeployment:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+}
+```
+
+### Step 4: Deploy to All Member Accounts
+
+#### Option A: Deploy to Entire Organization
+
+```bash
+# Get your root organizational unit ID
+ROOT_OU=$(aws organizations list-roots --region us-east-1 --query 'Roots[0].Id' --output text)
+
+# Deploy to all accounts in the organization
+aws cloudformation create-stack-instances \
+    --region us-east-1 \
+    --stack-set-name SecurityHubRoleDeployment \
+    --deployment-targets OrganizationalUnitIds=$ROOT_OU \
+    --regions us-east-1 \
+    --operation-preferences MaxConcurrentPercentage=20,FailureTolerancePercentage=5
+```
+
+#### Option B: Deploy to Specific Organizational Unit
+
+```bash
+# List your OUs to find the right one
+aws organizations list-organizational-units-for-parent --parent-id $ROOT_OU
+
+# Deploy to specific OU
+aws cloudformation create-stack-instances \
+    --region us-east-1 \
+    --stack-set-name SecurityHubRoleDeployment \
+    --deployment-targets OrganizationalUnitIds=ou-xxxx-xxxxxxxx \
+    --regions us-east-1
+```
+
+#### Option C: Deploy to Specific Accounts (Testing)
+
+```bash
+# Deploy to specific test accounts only
+aws cloudformation create-stack-instances \
+    --region us-east-1 \
+    --stack-set-name SecurityHubRoleDeployment \
+    --deployment-targets OrganizationalUnitIds=$ROOT_OU,AccountFilterType=INTERSECTION,Accounts=111111111111,222222222222 \
+    --regions us-east-1
+```
+
+Expected output:
+```json
+{
+    "OperationId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+}
+```
+
+### Step 5: Verify and Use
+
+1. **Run the product disablement script** as normal:
+```bash
+python3 productdisablement.py \
+    --assume_role_name SecurityHubRole \
+    --regions-to-disable us-east-1 \
+    --products aws/guardduty
+```
+
+## Steps
+
+### 1. Setup Execution Environment
+
+#### Option 1: Launch EC2 Instance
+* Launch an EC2 instance https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EC2_GetStarted.html
+* Attach an IAM role to the instance that has permissions to call AssumeRole for the target accounts
+* Install required software:
+    * APT: `sudo apt-get -y install python-pip python git`
+    * RPM: `sudo yum -y install python-pip python git`
+    * `sudo pip install boto3`
+* Clone the repository:
+    * `git clone https://github.com/awslabs/aws-securityhub-multiaccount-scripts.git`
+    * `cd aws-securityhub-multiaccount-scripts/multiaccount-product-disablement`
+* Copy your CSV file to the instance
+
+#### Option 2: Run Locally
+* Ensure you have credentials configured on your local machine that have permission to call AssumeRole
+* Install required software:
+    * **Windows:**
+        * Install Python https://www.python.org/downloads/windows/
+        * `pip install boto3`
+        * `git clone https://github.com/awslabs/aws-securityhub-multiaccount-scripts.git`
+        * `cd aws-securityhub-multiaccount-scripts\multiaccount-product-disablement`
+    * **Mac:**
+        * Install Python https://www.python.org/downloads/mac-osx/
+        * `pip install boto3`
+        * `git clone https://github.com/awslabs/aws-securityhub-multiaccount-scripts.git`
+        * `cd aws-securityhub-multiaccount-scripts/multiaccount-product-disablement`
+    * **Linux:**
+        * `sudo apt-get -y install python-pip python git` or `sudo yum -y install python-pip python git`
+        * `sudo pip install boto3`
+        * `git clone https://github.com/awslabs/aws-securityhub-multiaccount-scripts.git`
+        * `cd aws-securityhub-multiaccount-scripts/multiaccount-product-disablement`
+
+### 2. Create CSV File
+
+Create a CSV file with your account information. Each line should contain an account ID:
+
+**Format:**
+```
+123456789012
+234567890123
+345678901234
+```
+
+### 3. Execute Script
+
+```
+usage: productdisablement.py [-h] --assume_role_name ASSUME_ROLE_NAME
+                              --regions-to-disable REGIONS_TO_DISABLE
+                              --products PRODUCTS
+                              [input_file]
+
+Disable Security Hub CSPM product integrations across multiple AWS accounts
+
+positional arguments:
+  input_file            Optional: Path to CSV file containing account IDs (one per
+                        line). If not provided, uses all Security Hub member accounts
+
+required arguments:
+  --assume_role_name ASSUME_ROLE_NAME
+                        Role Name to assume in each account
+  --regions-to-disable REGIONS_TO_DISABLE
+                        Comma separated list of regions to disable products,
+                        or 'ALL' for all available regions (format: us-east-1, eu-west-1, etc.)
+  --products PRODUCTS   Comma separated list of product identifiers to disable
+                        (e.g., 'aws/guardduty,aws/macie' or product ARNs)
+
+optional arguments:
+  -h, --help            show this help message and exit
+```
+
+## Usage Examples
+
+### Using Auto-Discovery (No CSV File)
+
+When running from the Security Hub CSPM Delegated Administrator account, the script automatically discovers all Security Hub CSPM member accounts in your AWS Organization:
+
+```bash
+# Disable GuardDuty across ALL Security Hub member accounts in all regions
+python productdisablement.py \
+    --assume_role_name SecurityHubRole \
+    --regions-to-disable ALL \
+    --products "aws/guardduty"
+```
+
+```bash
+# Disable multiple products across ALL Security Hub member accounts in specific regions
+python productdisablement.py \
+    --assume_role_name SecurityHubRole \
+    --regions-to-disable us-east-1,us-west-2,eu-west-1 \
+    --products "aws/guardduty,aws/macie,aws/inspector2"
+```
+
+### Using CSV File
+
+When providing a CSV file, the script processes the accounts listed in the CSV:
+
+```bash
+# Disable GuardDuty for specific accounts (intersection of CSV and members)
+python productdisablement.py accounts.csv \
+    --assume_role_name SecurityHubRole \
+    --regions-to-disable ALL \
+    --products "aws/guardduty"
+```
+
+```bash
+# Disable multiple products in specific accounts and regions
+python productdisablement.py accounts.csv \
+    --assume_role_name SecurityHubRole \
+    --regions-to-disable us-east-1,us-west-2,eu-west-1 \
+    --products "aws/guardduty,aws/macie,aws/inspector2"
+```
+
+```bash
+# Disable Access Analyzer and Firewall Manager in specific accounts, us-east-1 only
+python productdisablement.py accounts.csv \
+    --assume_role_name SecurityHubRole \
+    --regions-to-disable us-east-1 \
+    --products "aws/access-analyzer,aws/firewall-manager"
+```
+
+## Product Identifiers
+
+You can specify products using either format:
+- **Short name format**: `aws/guardduty`, `aws/macie`, `aws/inspector2`
+- **Full ARN format**: `arn:aws:securityhub:us-east-1:123456789012:product-subscription/aws/guardduty`
+
+### Common AWS Product Identifiers
+
+| Product Identifier | Service |
+|-------------------|---------|
+| `aws/guardduty` | Amazon GuardDuty |
+| `aws/macie` | Amazon Macie |
+| `aws/inspector2` | Amazon Inspector |
+| `aws/access-analyzer` | IAM Access Analyzer |
+| `aws/firewall-manager` | AWS Firewall Manager |
+| `aws/health` | AWS Health |
+| `aws/systems-manager-patch-manager` | Systems Manager Patch Manager |
+
+
+## Important Notes
+
+* **Products not currently enabled are skipped** - The script will not error if a specified product is not enabled in an account/region
+* **Idempotent operation** - Safe to run multiple times; products already disabled will not cause errors
+* **Per-account, per-region processing** - Each account's enabled products are queried independently; the script only disables products that match the specified identifiers
+* **Continues on failure** - If one account fails, the script continues processing remaining accounts
+* **Works with any account type** - Standalone accounts, organization member accounts, or delegated administrator accounts

--- a/multiaccount-product-disablement/README.md
+++ b/multiaccount-product-disablement/README.md
@@ -100,8 +100,7 @@ Each member account must have an IAM role with:
    - Attach permission: `securityhub:DisableImportFindingsForProduct`
    - Set trust policy to allow DA account to assume the role (grants STS access)
 
-3. **Ensure accounts are Security Hub members:**
-   - From DA account: `aws securityhub create-members --region REGION --account-details ...`
+**Note:** The script will only process accounts that are Security Hub members of the Delegated Administrator account.
 
 ### Optional: CSV File
 
@@ -397,7 +396,7 @@ Create a CSV file with your account information. Each line should contain an acc
 ```
 usage: productdisablement.py [-h] --assume_role_name ASSUME_ROLE_NAME
                               --regions-to-disable REGIONS_TO_DISABLE
-                              --products PRODUCTS
+                              --products PRODUCTS [--dry-run]
                               [input_file]
 
 Disable Security Hub CSPM product integrations across multiple AWS accounts
@@ -417,9 +416,35 @@ required arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
+  --dry-run             Preview changes without actually disabling products.
+                        Shows what would be disabled.
 ```
 
 ## Usage Examples
+
+### Dry-Run Mode (Preview Changes)
+
+**Recommended:** Always run with `--dry-run` first to preview what will be changed before executing:
+
+```bash
+# Preview disabling GuardDuty across all accounts in all regions (NO CHANGES MADE)
+python productdisablement.py \
+    --assume_role_name SecurityHubRole \
+    --regions-to-disable ALL \
+    --products "aws/guardduty" \
+    --dry-run
+```
+
+```bash
+# Preview disabling multiple products in specific regions (NO CHANGES MADE)
+python productdisablement.py \
+    --assume_role_name SecurityHubRole \
+    --regions-to-disable us-east-1,us-west-2 \
+    --products "aws/guardduty,aws/macie" \
+    --dry-run
+```
+
+Once you've reviewed the dry-run output and confirmed the changes, remove the `--dry-run` flag to execute.
 
 ### Using Auto-Discovery (No CSV File)
 

--- a/multiaccount-product-disablement/README.md
+++ b/multiaccount-product-disablement/README.md
@@ -430,7 +430,7 @@ python productdisablement.py \
 python productdisablement.py \
     --assume_role_name SecurityHubRole \
     --regions-to-disable us-east-1,us-west-2,eu-west-1 \
-    --products "aws/guardduty,aws/macie,aws/inspector2"
+    --products "aws/guardduty,aws/macie,aws/inspector"
 ```
 
 ### Using CSV File
@@ -450,7 +450,7 @@ python productdisablement.py accounts.csv \
 python productdisablement.py accounts.csv \
     --assume_role_name SecurityHubRole \
     --regions-to-disable us-east-1,us-west-2,eu-west-1 \
-    --products "aws/guardduty,aws/macie,aws/inspector2"
+    --products "aws/guardduty,aws/macie,aws/inspector"
 ```
 
 ```bash
@@ -464,7 +464,7 @@ python productdisablement.py accounts.csv \
 ## Product Identifiers
 
 You can specify products using either format:
-- **Short name format**: `aws/guardduty`, `aws/macie`, `aws/inspector2`
+- **Short name format**: `aws/guardduty`, `aws/macie`, `aws/inspector`
 - **Full ARN format**: `arn:aws:securityhub:us-east-1:123456789012:product-subscription/aws/guardduty`
 
 ### Common AWS Product Identifiers
@@ -473,7 +473,7 @@ You can specify products using either format:
 |-------------------|---------|
 | `aws/guardduty` | Amazon GuardDuty |
 | `aws/macie` | Amazon Macie |
-| `aws/inspector2` | Amazon Inspector |
+| `aws/inspector` | Amazon Inspector |
 | `aws/access-analyzer` | IAM Access Analyzer |
 | `aws/firewall-manager` | AWS Firewall Manager |
 | `aws/health` | AWS Health |

--- a/multiaccount-product-disablement/SecurityHubRole-StackSet.yaml
+++ b/multiaccount-product-disablement/SecurityHubRole-StackSet.yaml
@@ -1,0 +1,45 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'Deploy SecurityHubRole for product disablement across member accounts'
+
+Parameters:
+  DelegatedAdminAccountId:
+    Type: String
+    Description: 'Account ID of the Security Hub Delegated Administrator'
+    AllowedPattern: '^\d{12}$'
+    ConstraintDescription: 'Must be a 12-digit AWS account ID'
+
+Resources:
+  SecurityHubRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: SecurityHubRole
+      Description: 'Role for Security Hub Delegated Admin to disable product integrations'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub 'arn:aws:iam::${DelegatedAdminAccountId}:root'
+            Action: 'sts:AssumeRole'
+      Policies:
+        - PolicyName: SecurityHubProductManagement
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'securityhub:DisableImportFindingsForProduct'
+                  - 'securityhub:ListMembers'
+                Resource: '*'
+      Tags:
+        - Key: Purpose
+          Value: SecurityHubProductDisablement
+        - Key: ManagedBy
+          Value: CloudFormationStackSet
+
+Outputs:
+  RoleArn:
+    Description: 'ARN of the created SecurityHub role'
+    Value: !GetAtt SecurityHubRole.Arn
+    Export:
+      Name: !Sub '${AWS::StackName}-RoleArn'

--- a/multiaccount-product-disablement/productdisablement.py
+++ b/multiaccount-product-disablement/productdisablement.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python
+"""
+Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+import boto3
+import re
+import argparse
+import time
+
+from collections import OrderedDict
+from botocore.exceptions import ClientError
+
+
+def assume_role(aws_account_id, role_name):
+    """
+    Assumes the provided role in each account and returns a Security Hub CSPM client
+    :param aws_account_id: AWS Account ID
+    :param role_name: Role to assume in target account
+    :return: boto3 Session object
+    """
+    
+    sts_client = boto3.client('sts')
+    
+    # Get the current partition
+    partition = sts_client.get_caller_identity()['Arn'].split(":")[1]
+    
+    response = sts_client.assume_role(
+        RoleArn='arn:{}:iam::{}:role/{}'.format(
+            partition,
+            aws_account_id,
+            role_name
+        ),
+        RoleSessionName='DisableSecurityHubCSPMProducts'
+    )
+    
+    # Storing STS credentials
+    session = boto3.Session(
+        aws_access_key_id=response['Credentials']['AccessKeyId'],
+        aws_secret_access_key=response['Credentials']['SecretAccessKey'],
+        aws_session_token=response['Credentials']['SessionToken']
+    )
+
+    print("Assumed session for {}.".format(aws_account_id))
+
+    return session
+
+
+def get_admin_members(sh_client, aws_region):
+    """
+    Returns a dict of current members of the Security Hub Administrator account
+    :param sh_client: SecurityHub client
+    :param aws_region: AWS Region of the Security Hub Administrator account
+    :return: dict of AwsAccountId:RelationshipStatus
+    """
+    
+    member_dict = dict()
+    
+    results = sh_client.list_members(
+        OnlyAssociated=False
+    )
+    
+    for member in results['Members']:
+        member_dict.update({member['AccountId']: member['MemberStatus']})
+        
+    while results.get("NextToken"):
+        results = sh_client.list_members(
+            OnlyAssociated=False,
+            NextToken=results['NextToken']
+        )
+        
+        for member in results['Members']:
+            member_dict.update({member['AccountId']: member['MemberStatus']})
+            
+    return member_dict
+
+
+if __name__ == '__main__':
+    
+    # Setup command line arguments
+    parser = argparse.ArgumentParser(description='Disable Security Hub CSPM product integrations across multiple AWS accounts')
+    parser.add_argument('input_file', nargs='?', type=argparse.FileType('r'), help='Optional: Path to CSV file containing account IDs (one per line). If not provided, uses all Security Hub member accounts')
+    parser.add_argument('--assume_role_name', type=str, required=True, help="Role Name to assume in each account")
+    parser.add_argument('--regions-to-disable', type=str, required=True, help="Comma separated list of regions to disable products, or 'ALL' for all available regions (format: us-east-1, eu-west-1, etc.)")
+    parser.add_argument('--products', type=str, required=True, help="Comma separated list of product identifiers to disable (e.g., 'aws/guardduty,aws/macie' or product ARNs)")
+    args = parser.parse_args()
+    
+    # Parse product list
+    product_identifiers = [str(item).strip() for item in args.products.split(',')]
+    print("Products to disable: {}".format(product_identifiers))
+    
+    # Getting Security Hub regions
+    session = boto3.session.Session()
+    
+    securityhub_regions = []
+    if args.regions_to_disable.upper() == 'ALL':
+        securityhub_regions = session.get_available_regions('securityhub')
+        print("Will check for members in all available Security Hub CSPM regions: {}".format(securityhub_regions))
+    else:
+        securityhub_regions = [str(item).strip() for item in args.regions_to_disable.split(',')]
+        
+        # Validate against actual available Security Hub regions
+        # This covers standard, GovCloud (us-gov-*), China (cn-*), and ISO (us-iso-*) regions
+        available_regions = session.get_available_regions('securityhub')
+        invalid_regions = [r for r in securityhub_regions if r not in available_regions]
+        
+        if invalid_regions:
+            print("ERROR: Invalid or unavailable Security Hub regions: {}".format(invalid_regions))
+            print("Available regions: {}".format(', '.join(sorted(available_regions))))
+            exit(1)
+        
+        print("Will check for members in these regions: {}".format(securityhub_regions))
+    
+    # Get the DA account ID and partition (needed for both CSV and non-CSV modes)
+    sts_client = session.client('sts')
+    caller_identity = sts_client.get_caller_identity()
+    da_account_id = caller_identity['Account']
+    partition = caller_identity['Arn'].split(":")[1]
+    print("Detected partition: {}".format(partition))
+    
+    # Initialize members dict for all regions
+    members = {}
+    for aws_region in securityhub_regions:
+        members[aws_region] = {}
+    
+    # If CSV file provided, read account IDs from it
+    if args.input_file:
+        print("CSV file provided - will process accounts from CSV")
+        csv_accounts = set()
+        for acct in args.input_file.readlines():
+            split_line = acct.rstrip().split(",")
+            if len(split_line) < 1:
+                print("Unable to process line: {}".format(acct))
+                continue
+            
+            account_id = split_line[0].strip()
+            
+            if not re.match(r'[0-9]{12}', account_id):
+                print("Invalid account number {}, skipping".format(account_id))
+                continue
+                
+            csv_accounts.add(account_id)
+        
+        # Use CSV accounts directly (no member fetching needed)
+        accounts_to_process = csv_accounts
+        
+        # Populate members dict to pass membership check during processing
+        for aws_region in securityhub_regions:
+            for account in csv_accounts:
+                members[aws_region][account] = 'CSV_PROVIDED'
+        
+        print("Processing {} accounts from CSV file".format(len(accounts_to_process)))
+            
+    else:
+        # No CSV provided - fetch and use all member accounts + DA account
+        print("No CSV file provided - will fetch all Security Hub member accounts")
+        
+        # Get Security Hub member accounts from all regions (only when needed)
+        admin_clients = {}
+        all_member_accounts = set()
+        
+        for aws_region in securityhub_regions:
+            admin_clients[aws_region] = session.client('securityhub', region_name=aws_region)
+            try:
+                members[aws_region] = get_admin_members(admin_clients[aws_region], aws_region)
+                all_member_accounts.update(members[aws_region].keys())
+                print("Found {} member accounts in region {}".format(len(members[aws_region]), aws_region))
+            except ClientError as e:
+                print("Error listing members in region {}: {}".format(aws_region, repr(e)))
+                members[aws_region] = {}
+        
+        print("Total unique Security Hub CSPM member accounts across all regions: {}".format(len(all_member_accounts)))
+        
+        accounts_to_process = all_member_accounts.copy()
+        
+        # Add the DA (Delegated Administrator) account to the list and to members dict
+        accounts_to_process.add(da_account_id)
+        # Add DA account to members dict for all regions so it doesn't get skipped
+        for aws_region in securityhub_regions:
+            members[aws_region][da_account_id] = 'DA_ACCOUNT'
+        print("Added DA account {} to the list for processing".format(da_account_id))
+    
+    if len(accounts_to_process) == 0:
+        print("ERROR: No accounts to process. Exiting.")
+        exit(1)
+    
+    print("Total accounts to process: {}".format(len(accounts_to_process)))
+    print("Disabling products in regions: {}".format(securityhub_regions))
+    
+    # Processing accounts
+    failed_accounts = []
+    for account in sorted(accounts_to_process):
+        try:
+            # For DA account, use current session; for others, assume role
+            if account == da_account_id:
+                print("Using current session for DA account {}.".format(account))
+                account_session = boto3.session.Session()
+            else:
+                account_session = assume_role(account, args.assume_role_name)
+            
+            for aws_region in securityhub_regions:
+                # Check if account is a member in this specific region
+                if account not in members[aws_region]:
+                    print('Account {account} is not a Security Hub CSPM member in region {region} - skipping'.format(
+                        account=account,
+                        region=aws_region
+                    ))
+                    continue
+                
+                print('Beginning {account} in {region}'.format(
+                    account=account,
+                    region=aws_region
+                ))
+                
+                try:
+                    sh_client = account_session.client('securityhub', region_name=aws_region)
+                except ClientError as e:
+                    error_code = e.response['Error']['Code']
+                    if error_code == 'UnrecognizedClientException':
+                        print('  [SKIP] Region not enabled for account: {}'.format(aws_region))
+                        continue
+                    else:
+                        print('  [FAIL] {}'.format(repr(e)))
+                        failed_accounts.append({
+                            account: "Failed to create client in {}".format(aws_region)
+                        })
+                        continue
+                
+                # Directly disable specified products (idempotent - safe if already disabled)
+                for product_identifier in product_identifiers:
+                    try:
+                        # Construct ProductSubscriptionArn with correct partition
+                        # Format: arn:{partition}:securityhub:region:account-id:product-subscription/provider/product
+                        # Supports: aws, aws-us-gov, aws-cn, aws-iso, aws-iso-b
+                        product_arn = 'arn:{partition}:securityhub:{region}:{account}:product-subscription/{product}'.format(
+                            partition=partition,
+                            region=aws_region,
+                            account=account,
+                            product=product_identifier
+                        )
+                        
+                        sh_client.disable_import_findings_for_product(
+                            ProductSubscriptionArn=product_arn
+                        )
+                        print('  Disabled product {product} in account {account} region {region}'.format(
+                            product=product_identifier,
+                            account=account,
+                            region=aws_region
+                        ))
+                        
+                    except ClientError as e:
+                        error_code = e.response['Error']['Code']
+                        error_message = e.response['Error'].get('Message', '')
+                        
+                        # Skip expected cases
+                        if error_code == 'ResourceNotFoundException':
+                            print('  [SKIP] Product not enabled: {}'.format(product_identifier))
+                        elif error_code == 'InvalidAccessException' and ('not subscribed to AWS Security Hub' in error_message or 'SecurityHub is not enabled' in error_message.lower()):
+                            print('  [SKIP] Security Hub not enabled')
+                        elif error_code == 'UnrecognizedClientException':
+                            print('  [SKIP] Region not enabled for account: {}'.format(aws_region))
+                            break  # Skip remaining products for this region
+                        else:
+                            # Everything else - print the raw error
+                            print('  [FAIL] {}'.format(repr(e)))
+                            failed_accounts.append({
+                                account: "{} in {}".format(product_identifier, aws_region)
+                            })
+                
+                print('Finished {account} in {region}'.format(account=account, region=aws_region))
+                    
+        except ClientError as e:
+            error_msg = e.response.get('Error', {}).get('Message', str(e))
+            print("[FAIL] Account {}: {}".format(account, error_msg))
+            failed_accounts.append({
+                account: error_msg
+            })
+
+    if len(failed_accounts) > 0:
+        print("---------------------------------------------------------------")
+        print("Failed Accounts")
+        print("---------------------------------------------------------------")
+        for account in failed_accounts:
+            for account_id, message in account.items():
+                print("{}: \n\t{}".format(account_id, message))
+        print("---------------------------------------------------------------")


### PR DESCRIPTION
Add a new script to disable Security Hub product integrations across multiple accounts in an organization.

Key features:
- Support for both CSV file input and automatic member discovery
- Multi-partition support (aws, aws-us-gov, aws-cn, aws-iso, aws-iso-b)
- Role assumption for cross-account operations
- CloudFormation StackSet template for automated role deployment
- Comprehensive error handling and validation

Script capabilities:
- Disable specified products across Security Hub member accounts
- Auto-detect AWS partition for correct ARN construction
- Filter by regions with opt-in region handling
- Support for Security Hub Delegated Administrator setup

Usage:
  python3 productdisablement.py [CSV_FILE] --assume_role_name ROLE --regions-to-disable REGIONS --products PRODUCTS

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
